### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "react": "15.3.2",
     "react-native": "0.36.0",
-    "react-native-page-swiper": "^0.3.0",
     "react-native-swiper": "^1.5.2"
   },
   "jest": {


### PR DESCRIPTION
Couldn't complete `npm install`. This dependency, which is unused, requires react-native >=0.18.0 <=0.29.0